### PR TITLE
added 1 as acceptable return value

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Set the raid flag on file system on /dev/sdb1
 ```ruby
 parted_disk "/dev/sdb1" do
   flag_name "raid"
-  action: setflag
+  action :setflag
 end
 ```
 

--- a/providers/disk.rb
+++ b/providers/disk.rb
@@ -21,6 +21,7 @@
 action :mklabel do
   execute "parted #{new_resource.device} --script -- mklabel #{new_resource.label_type}" do
     new_resource.updated_by_last_action(true)
+    returns [0, 1]
 
     not_if "parted #{new_resource.device} --script -- print |grep 'Partition Table: #{new_resource.label_type}'"
   end
@@ -29,6 +30,7 @@ end
 action :mkpart do
   execute "parted #{new_resource.device} --script -- mkpart #{new_resource.part_type} #{new_resource.file_system} 1 -1" do
     new_resource.updated_by_last_action(true)
+    returns [0, 1]
 
     # Number  Start   End    Size   File system  Name  Flags
     #  1      17.4kB  537GB  537GB               xfs
@@ -50,6 +52,7 @@ end
 action :setflag do
   execute "parted #{new_resource.device} --script -- set 1 #{new_resource.flag_name} on" do
     new_resource.updated_by_last_action(true)
+    returns [0, 1]
 
     # Number  Start   End    Size   Type     File system  Flags
     #  1      1049kB  107GB  107GB  primary               boot


### PR DESCRIPTION
in some circumstances, the parted command will exit(1) even though its a warning, causing the chef run to abort.

``````
WARNING: the kernel failed to re-read the partition table on /dev/xvdj (Device or resource busy). As a result, it may not reflect all of your changes until after reboot. ```
``````
