### PR TITLE
added attributes to define partition size

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ parted_disk "/dev/sdb1" do
 end
 ```
 
+Make an ext4 file system on /dev/sdb1 with a size of 800GB (default in MB)
+
+```ruby
+parted_disk "/dev/sdb1" do
+  file_system "ext4"
+  part_start  "1"
+  part_end    "819200"
+
+  action :mkfs
+end
+```
+
 Set the raid flag on file system on /dev/sdb1
 ```ruby
 parted_disk "/dev/sdb1" do

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'john@dewey.ws'
 license 'Apache 2.0'
 description 'Installs/Configures parted'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.0.0'
+version '2.1.0'
 
 recipe 'parted', 'Installs/Configures parted'
 

--- a/providers/disk.rb
+++ b/providers/disk.rb
@@ -27,7 +27,8 @@ action :mklabel do
 end
 
 action :mkpart do
-  execute "parted #{new_resource.device} --script -- mkpart #{new_resource.part_type} #{new_resource.file_system} 1 -1" do
+  execute "parted #{new_resource.device} --script -- mkpart #{new_resource.part_type} #{new_resource.file_system} \
+#{new_resource.part_start} #{new_resource.part_end}" do
     new_resource.updated_by_last_action(true)
 
     # Number  Start   End    Size   File system  Name  Flags

--- a/resources/disk.rb
+++ b/resources/disk.rb
@@ -24,6 +24,8 @@ attribute :device, kind_of: String, name_attribute: true
 attribute :label_type, kind_of: String, default: 'gpt'
 attribute :file_system, kind_of: String, default: 'ext4'
 attribute :part_type, kind_of: String, default: 'primary'
+attribute :part_start, kind_of: String, default: '1'
+attribute :part_end, kind_of: String, default: '-1'
 attribute :flag_name, kind_of: String, default: 'boot'
 
 def initialize(*args)


### PR DESCRIPTION
Added the attributes part_start (default 1) and part_end (default -1) to add the possibility to define the size of the partition in MB. Bumped one minor version. Added short example for usage in README.
