### PR TITLE
Corrected a matcher deprecation

### DIFF
--- a/spec/matchers_spec.rb
+++ b/spec/matchers_spec.rb
@@ -3,7 +3,7 @@
 require_relative 'spec_helper'
 
 describe 'parted::_test' do
-  let(:chef_run) { ChefSpec::Runner.new.converge(described_recipe) }
+  let(:chef_run) { ChefSpec::ServerRunner.new.converge(described_recipe) }
 
   it 'provides a chefspec matcher for mklabel' do
     expect(chef_run).to mklabel_parted_disk('making label')


### PR DESCRIPTION
    DEPRECATION] `ChefSpec::Runner' is deprecated. Please use `ChefSpec::SoloRunner' or `ChefSpec::ServerRunner' instead. (called from spec/matchers_spec.rb:6:in `block (2 levels) in <top (required)>')