### PR TITLE
Allow for the creation of logical partition types.

### DIFF
--- a/providers/disk.rb
+++ b/providers/disk.rb
@@ -33,7 +33,7 @@ action :mkpart do
 
     # Number  Start   End    Size   File system  Name  Flags
     #  1      17.4kB  537GB  537GB               xfs
-    not_if "parted #{new_resource.device} --script -- print |grep #{new_resource.part_type}"
+    not_if "parted #{new_resource.device} --script -- print |sed '1,/^Number/d' |grep #{new_resource.part_type}"
   end
 end
 

--- a/spec/_test_spec.rb
+++ b/spec/_test_spec.rb
@@ -24,7 +24,7 @@ describe 'parted::_test' do
   end
 
   it 'does not partition when exists' do
-    stub_command('parted /dev/sdb --script -- print |grep primary')
+    stub_command('parted /dev/sdb --script -- print |sed \'1,/^Number/d\' |grep primary')
       .and_return true
     cmd = 'parted /dev/sdb --script -- mkpart primary ext4 1 -1'
     expect(chef_run).not_to run_execute cmd


### PR DESCRIPTION
Currently, the cookbook doesn't allow for the creation of `logical` `part_types`, this is because the guard greps for `logical` in the `parted` output, which _always_ includes `logical` because of the line describing Sector size:

`Sector size (logical/physical): 512B/512B`

To get around this, I've added a `sed` command to the guard to strip out everything but the actual partition information.